### PR TITLE
Update to Loading System

### DIFF
--- a/Assets/Scripts/Loading/LoadLevel.cs
+++ b/Assets/Scripts/Loading/LoadLevel.cs
@@ -1,6 +1,5 @@
 // Morgan Houston
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
@@ -14,7 +13,9 @@ public class LoadLevel : MonoBehaviour
     public GameObject loadingBarEnd;
     [Tooltip("The loading bar.")]
     public Slider loadingBar;
+
     private float progress;
+    private const float ALMOST_COMPLETE = 0.9999f;
 
     #endregion
 
@@ -36,9 +37,9 @@ public class LoadLevel : MonoBehaviour
 
         AsyncOperation loading = SceneManager.LoadSceneAsync(index);
 
-        while(!loading.isDone)
+        while (!loading.isDone)
         {
-            progress = Mathf.Clamp(loading.progress / .9f, 0f, 0.9999f);
+            progress = Mathf.Clamp(loading.progress / .9f, 0f, ALMOST_COMPLETE);
 
             loadingBar.value = progress * 100f;
             player.transform.position = loadingBarEnd.transform.position;

--- a/Assets/Scripts/Loading/Loading.cs
+++ b/Assets/Scripts/Loading/Loading.cs
@@ -1,12 +1,11 @@
 // Morgan Houston
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class Loading : MonoBehaviour
 {
     [Tooltip("The level to be loaded.")]
-    public int levelToLoad;
+    //public int levelToLoad;
+    public SceneLoader.Levels levelToLoad;
 
     /// <summary>
     /// Once player enters trigger area load loading scene and level to load.
@@ -14,8 +13,8 @@ public class Loading : MonoBehaviour
     /// <param name="other">The object that triggered</param>
     private void OnTriggerEnter(Collider other)
     {
-        if(other.CompareTag("Player"))
-            SceneLoader.LoadLevel(levelToLoad);
+        if (other.CompareTag("Player"))
+            SceneLoader.LoadLevel((int)levelToLoad);
     }
 
 }

--- a/Assets/Scripts/Loading/SceneLoader.cs
+++ b/Assets/Scripts/Loading/SceneLoader.cs
@@ -20,7 +20,7 @@ public static class SceneLoader
     public static void LoadLevel(int level)
     {
         levelToLoad = level;
-        SceneManager.LoadSceneAsync(0);
+        SceneManager.LoadSceneAsync((int)Levels.Loading);
     }
 
     #endregion

--- a/Assets/Scripts/Loading/SceneLoader.cs
+++ b/Assets/Scripts/Loading/SceneLoader.cs
@@ -1,5 +1,4 @@
 // Morgan Houston
-using System.ComponentModel;
 using UnityEngine.SceneManagement;
 
 public static class SceneLoader
@@ -7,6 +6,7 @@ public static class SceneLoader
     #region Fields
 
     public static int levelToLoad = 1;
+    public enum Levels { Loading, MainMenu, Castle, Scavenger, Magician, Thieves };
 
     #endregion
 

--- a/Assets/Scripts/Loading/SceneLoader.cs
+++ b/Assets/Scripts/Loading/SceneLoader.cs
@@ -6,7 +6,7 @@ public static class SceneLoader
     #region Fields
 
     public static int levelToLoad = 1;
-    public enum Levels { Loading, MainMenu, Castle, Scavenger, Magician, Thieves };
+    public enum Levels { Loading, MainMenu, Castle, Scavenger, ScavengerMinigame, Magician, MagicianMinigame, Thieves, ThievesMinigame };
 
     #endregion
 

--- a/Assets/Scripts/Managers/MainManager.cs
+++ b/Assets/Scripts/Managers/MainManager.cs
@@ -1,5 +1,4 @@
-using System.Collections;
-using System.Collections.Generic;
+// Morgan Houston
 using UnityEditor;
 using UnityEngine;
 
@@ -13,7 +12,7 @@ public class MainManager : MonoBehaviour
     {
         // Get last saved scene then load scene
         // loading castle scene for now
-        SceneLoader.LoadLevel(2);
+        SceneLoader.LoadLevel((int)SceneLoader.Levels.Castle);
     }
 
     public void Exit()


### PR DESCRIPTION
SceneLoader has an enum called Levels with each level name and their index. Changed Loading to include enum and can select what level you want to load with a drop down in the inspector. There is also an example in MainManager showing loading a scene from a UI button.